### PR TITLE
Move service description lower

### DIFF
--- a/recipes/_configure.rb
+++ b/recipes/_configure.rb
@@ -1,8 +1,5 @@
 # encoding: utf-8
 
-# Include service definition now
-include_recipe 'vsftpd::_define_service'
-
 directory node['vsftpd']['etcdir'] do
   action :create
   user 'root'
@@ -36,3 +33,6 @@ config = value_for_platform_family(
     notifies :restart, 'service[vsftpd]', :delayed
   end
 end
+
+# Include service definition now
+include_recipe 'vsftpd::_define_service'


### PR DESCRIPTION
When service is in error state, system will attempt to restart vsftpd before updating /etc/vsftpd.conf.  Chef will forever fail. Updated recipes/_configure.rb to put service description below template calls.  The "notifies" directive still works correctly as it appears the string 'service[vsftpd]' is resolved during the run-phase instead of compile-phase.