### PR TITLE
Fix vsftpd with ssl configuration

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url        'https://github.com/TheSerapher/chef-vsftpd'
 license           'Apache 2.0'
 description       'Installs/configures vsftpd'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '0.4.0'
+version           '0.4.1'
 recipe            'vsftpd::default', 'Installs/configures vsftpd'
 
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 include_recipe 'vsftpd::_install'
-include_recipe 'vsftpd::_configure'
 include_recipe 'vsftpd::_ssl' unless node['vsftpd']['ssl']['enabled'] == false
+include_recipe 'vsftpd::_configure'


### PR DESCRIPTION
Fix issue with vsftpd with SSL restart fail.

Issue: vsftpd service with SSL support can not be restarted, because of SSL cert/key does not exist. Incorrect operations order